### PR TITLE
Allow configurable Dialer

### DIFF
--- a/cmd/marionette/client.go
+++ b/cmd/marionette/client.go
@@ -68,8 +68,8 @@ func (cmd *ClientCommand) Run(args []string) error {
 	streamSet.TracePath = fs.TracePath
 
 	// Create dialer to remote server.
-	dialer, err := marionette.NewDialer(doc, *serverIP, streamSet)
-	if err != nil {
+	dialer := marionette.NewDialer(doc, *serverIP, streamSet)
+	if err := dialer.Open(); err != nil {
 		return err
 	}
 

--- a/cmd/marionette/pt_client.go
+++ b/cmd/marionette/pt_client.go
@@ -141,8 +141,8 @@ func (cmd *PTClientCommand) handleConn(connection *pt.SocksConn, doc *mar.Docume
 	defer streamSet.Close()
 
 	// Create dialer to remote server.
-	dialer, err := marionette.NewDialer(doc, host, streamSet)
-	if err != nil {
+	dialer := marionette.NewDialer(doc, host, streamSet)
+	if err := dialer.Open(); err != nil {
 		log.Printf("Unable to create dialer: %s", err)
 		connection.Reject()
 		return


### PR DESCRIPTION
This pull request changes `marionette.Dialer` to add a `net.Dialer` field that can be configured by the caller. This change required that initialization and initiation phases be separated out into `NewDialer()` & `Dialer.Open()`, respectively.

Usage:

```go
d := marionette.NewDialer(doc, "localhost", streamSet)
d.Dialer.Timeout = 1 * time.Minute
if err := d.Open(); err != nil {
	return err
}

conn, err := d.Dial()
```