### PR TITLE
Provided ability to specify underlying NetDialer when calling NewDialer

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -40,6 +40,7 @@ func NewDialer(doc *mar.Document, addr string, streamSet *StreamSet) *Dialer {
 		addr:      addr,
 		doc:       doc,
 		streamSet: streamSet,
+		Dialer:    &net.Dialer{},
 	}
 	d.ctx, d.cancel = context.WithCancel(context.Background())
 	return d


### PR DESCRIPTION
I tried the example mentioned in the Readme and got a segmentation violation because the marionette Dialer's `Dialer` field was nil. To fix, I've updated `NewDialer` to accept the underlying `NetDialer` and default it to a `net.Dialer` if unspecified.