### PR TITLE
Simplify the build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /third_party
 /vendor
+/marionette

--- a/build_third_party.sh
+++ b/build_third_party.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -ex
+
+# This script will build the third party libraries and put in the correct file
+# paths to make it possible to build the binary without installing the
+# dependencies system wide.
+PKG_TOPDIR=$(cd $(dirname $0) && pwd -P)
+
+cd $PKG_TOPDIR/third_party/openfst && ./configure --enable-static=yes && make
+cd $PKG_TOPDIR/third_party/re2 && make
+
+cd $PKG_TOPDIR/third_party
+curl -LsO https://gmplib.org/download/gmp/gmp-6.1.2.tar.bz2
+PKG_CHECKSUM="5275bb04f4863a13516b2f39392ac5e272f5e1bb8057b18aec1c9b79d73d8fb2"
+REAL_CHECKSUM=$(shasum -a 256 gmp-6.1.2.tar.bz2 | awk '{print $1}')
+[ $PKG_CHECKSUM = "$REAL_CHECKSUM" ]
+tar -xvjf $PKG_TOPDIR/third_party/gmp-6.1.2.tar.bz2
+cd $PKG_TOPDIR/third_party/gmp-6.1.2 && ./configure --enable-cxx && make
+
+mkdir -p $PKG_TOPDIR/third_party/libs/
+
+cp $PKG_TOPDIR/third_party/gmp-6.1.2/.libs/libgmp.a $PKG_TOPDIR/third_party/libs/
+cp $PKG_TOPDIR/third_party/re2/obj/libre2.a $PKG_TOPDIR/third_party/libs/
+cp $PKG_TOPDIR/third_party/openfst/src/lib/.libs/libfst.a $PKG_TOPDIR/third_party/libs/
+cp $PKG_TOPDIR/third_party/openfst/src/script/.libs/libfstscript.a $PKG_TOPDIR/third_party/libs/

--- a/fte/dfa.go
+++ b/fte/dfa.go
@@ -1,7 +1,7 @@
 package fte
 
 // #cgo CXXFLAGS: -std=c++11
-// #cgo LDFLAGS: -ldl /usr/local/lib/libgmp.a
+// #cgo LDFLAGS: -ldl ${SRCDIR}/../third_party/libs/libgmp.a
 // #include <stdlib.h>
 // #include <stdint.h>
 // void* _dfa_new(char *tbl, const uint32_t max_len);

--- a/regex2dfa/regex2dfa.go
+++ b/regex2dfa/regex2dfa.go
@@ -1,7 +1,7 @@
 package regex2dfa
 
-// #cgo CXXFLAGS: -std=c++11 -DMARIONETTE -I${SRCDIR}/../third_party/re2
-// #cgo LDFLAGS: -ldl /usr/local/lib/libfst.a /usr/local/lib/libfstscript.a /usr/local/lib/libre2.a
+// #cgo CXXFLAGS: -std=c++11 -DMARIONETTE -I${SRCDIR}/../third_party/re2/ -I${SRCDIR}/../third_party/openfst/src/include/
+// #cgo LDFLAGS: -ldl ${SRCDIR}/../third_party/libs/libfst.a ${SRCDIR}/../third_party/libs/libfstscript.a ${SRCDIR}/../third_party/libs/libre2.a
 // #include <stdlib.h>
 // #include <stdint.h>
 // int _regex2dfa(const char* input_regex, uint32_t input_regex_len, char **out, size_t *sz);


### PR DESCRIPTION
In this pull request I make it possible to build a marionette executable without needing to install the required dependencies system wide.

This is similar in approach to what we do to build and link [measurement-kit](https://github.com/measurement-kit/measurement-kit) (the OONI C++ network measurement library) from go code.

The jist of it is you simply have to run `build_third_party.sh` from the root of the repository and then you can simply invoke: `go build ./cmd/marionette`.

The motivation to do this is that I wanted to try building marionette on macOS without having to run commands with sudo and polluting my /usr/local/lib.

I have tested this on macOS 10.12.6 and was able to build a `marionette` executable that as far as I can tell works (though I didn't do extensive testing of it).

I believe it should work out-of-the box on linux based systems too, since the paths for the static library builds should be the same.