### PR TITLE
Compilation and linking fixes

### DIFF
--- a/regex2dfa/regex2dfa.go
+++ b/regex2dfa/regex2dfa.go
@@ -1,7 +1,7 @@
 package regex2dfa
 
 // #cgo CXXFLAGS: -std=c++11 -DMARIONETTE -I${SRCDIR}/../third_party/re2/ -I${SRCDIR}/../third_party/openfst/src/include/
-// #cgo LDFLAGS: -ldl ${SRCDIR}/../third_party/libs/libfst.a ${SRCDIR}/../third_party/libs/libfstscript.a ${SRCDIR}/../third_party/libs/libre2.a
+// #cgo LDFLAGS: ${SRCDIR}/../third_party/libs/libfst.a ${SRCDIR}/../third_party/libs/libfstscript.a ${SRCDIR}/../third_party/libs/libre2.a -ldl
 // #include <stdlib.h>
 // #include <stdint.h>
 // int _regex2dfa(const char* input_regex, uint32_t input_regex_len, char **out, size_t *sz);

--- a/third_party/openfst/src/include/fst/replace.h
+++ b/third_party/openfst/src/include/fst/replace.h
@@ -1250,7 +1250,7 @@ class ArcIterator< ReplaceFst<A, T, C> > {
     // If state is already cached, use cached arcs array.
     if (fst_.GetImpl()->HasArcs(state_)) {
       (fst_.GetImpl())
-          ->template CacheBaseImpl<typename C::State, C>::InitArcIterator(
+          ->CacheBaseImpl<typename C::State, C>::InitArcIterator(
               state_, &cache_data_);
       num_arcs_ = cache_data_.narcs;
       arcs_ = cache_data_.arcs;      // 'arcs_' is a ptr to the cached arcs.


### PR DESCRIPTION
These are fixes to get marionette to build with new compilers (gcc >=7), and avoid linking errors.